### PR TITLE
Fix a few compilation problems

### DIFF
--- a/databases/mariadb-connector-odbc/Makefile
+++ b/databases/mariadb-connector-odbc/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	mariadb
-PORTVERSION=	3.0.1
+PORTVERSION=	3.0.2
 CATEGORIES=	databases ipv6
 MASTER_SITES=	http://ftp.osuosl.org/pub/${SITESDIR}/ \
 		http://mirrors.supportex.net/${SITESDIR}/ \
@@ -12,7 +12,7 @@ MASTER_SITES=	http://ftp.osuosl.org/pub/${SITESDIR}/ \
 		http://mirror.layerjet.com/${SITESDIR}/ \
 		http://mirror.switch.ch/mirror/${SITESDIR}/
 PKGNAMESUFFIX=	-connector-odbc
-DISTNAME=	${PORTNAME}${PKGNAMESUFFIX}-${PORTVERSION}-beta-src
+DISTNAME=	${PORTNAME}${PKGNAMESUFFIX}-${PORTVERSION}-ga-src
 
 MAINTAINER=	brnrd@FreeBSD.org
 COMMENT=	MariaDB database connector for C

--- a/databases/mariadb-connector-odbc/Makefile
+++ b/databases/mariadb-connector-odbc/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	mariadb
-PORTVERSION=	3.0.0
+PORTVERSION=	3.0.1
 CATEGORIES=	databases ipv6
 MASTER_SITES=	http://ftp.osuosl.org/pub/${SITESDIR}/ \
 		http://mirrors.supportex.net/${SITESDIR}/ \
@@ -12,7 +12,7 @@ MASTER_SITES=	http://ftp.osuosl.org/pub/${SITESDIR}/ \
 		http://mirror.layerjet.com/${SITESDIR}/ \
 		http://mirror.switch.ch/mirror/${SITESDIR}/
 PKGNAMESUFFIX=	-connector-odbc
-DISTNAME=	${PORTNAME}${PKGNAMESUFFIX}-${PORTVERSION}-alpha-src
+DISTNAME=	${PORTNAME}${PKGNAMESUFFIX}-${PORTVERSION}-beta-src
 
 MAINTAINER=	brnrd@FreeBSD.org
 COMMENT=	MariaDB database connector for C

--- a/databases/mariadb-connector-odbc/Makefile
+++ b/databases/mariadb-connector-odbc/Makefile
@@ -25,7 +25,7 @@ CONFLICTS_INSTALL=	mariadb[0-9]*-client-* \
 			mysql[0-9]*-client-* \
 			percona[0-9]*-client-*
 
-USES=		cmake
+USES=		cmake ssl
 USE_LDCONFIG=	${PREFIX}/lib/mariadbconnector-odbc
 SITESDIR=	${PORTNAME}/connector-odbc-${PORTVERSION}
 DOCSDIR=	${PREFIX}/share/doc/mysql
@@ -35,7 +35,8 @@ BUILD_DEPENDS=  unixODBC>=2.2.14_1:databases/unixODBC \
 LIB_DEPENDS=    libodbc.so:databases/unixODBC
 RUN_DEPENDS=	mariadb-connector-c>=3.0.2:databases/mariadb-connector-c
 
-CMAKE_ARGS+=	-DCOMPILATION_COMMENT="FreeBSD Ports"
+CMAKE_ARGS+=	-DCOMPILATION_COMMENT="FreeBSD Ports" \
+				-DWITH_OPENSSL="YES"
 
 PLIST_FILES=	lib/libmaodbc.so
 

--- a/databases/mariadb-connector-odbc/Makefile
+++ b/databases/mariadb-connector-odbc/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	mariadb
-PORTVERSION=	2.0.14
+PORTVERSION=	3.0.0
 CATEGORIES=	databases ipv6
 MASTER_SITES=	http://ftp.osuosl.org/pub/${SITESDIR}/ \
 		http://mirrors.supportex.net/${SITESDIR}/ \
@@ -12,7 +12,7 @@ MASTER_SITES=	http://ftp.osuosl.org/pub/${SITESDIR}/ \
 		http://mirror.layerjet.com/${SITESDIR}/ \
 		http://mirror.switch.ch/mirror/${SITESDIR}/
 PKGNAMESUFFIX=	-connector-odbc
-DISTNAME=	${PORTNAME}${PKGNAMESUFFIX}-${PORTVERSION}-ga-src
+DISTNAME=	${PORTNAME}${PKGNAMESUFFIX}-${PORTVERSION}-alpha-src
 
 MAINTAINER=	brnrd@FreeBSD.org
 COMMENT=	MariaDB database connector for C
@@ -27,13 +27,13 @@ CONFLICTS_INSTALL=	mariadb[0-9]*-client-* \
 
 USES=		cmake
 USE_LDCONFIG=	${PREFIX}/lib/mariadbconnector-odbc
-SITESDIR=	${PORTNAME}/connector-odbc-${PORTVERSION}/source
+SITESDIR=	${PORTNAME}/connector-odbc-${PORTVERSION}
 DOCSDIR=	${PREFIX}/share/doc/mysql
 
 BUILD_DEPENDS=  unixODBC>=2.2.14_1:databases/unixODBC \
-		mariadbconnector-c>=2.3.0:databases/mariadb-connector-c
+		mariadb-connector-c>=3.0.2:databases/mariadb-connector-c
 LIB_DEPENDS=    libodbc.so:databases/unixODBC
-RUN_DEPENDS=	mariadbconnector-c>=2.3.0:databases/mariadb-connector-c
+RUN_DEPENDS=	mariadb-connector-c>=3.0.2:databases/mariadb-connector-c
 
 CMAKE_ARGS+=	-DCOMPILATION_COMMENT="FreeBSD Ports"
 

--- a/databases/mariadb-connector-odbc/Makefile
+++ b/databases/mariadb-connector-odbc/Makefile
@@ -27,13 +27,13 @@ CONFLICTS_INSTALL=	mariadb[0-9]*-client-* \
 
 USES=		cmake
 USE_LDCONFIG=	${PREFIX}/lib/mariadbconnector-odbc
-SITESDIR=	${PORTNAME}/${PKGNAMESUFFIX}-${PORTVERSION}/source
+SITESDIR=	${PORTNAME}/connector-odbc-${PORTVERSION}/source
 DOCSDIR=	${PREFIX}/share/doc/mysql
 
 BUILD_DEPENDS=  unixODBC>=2.2.14_1:databases/unixODBC \
-		mariadb-connector-c>=2.3.0:databases/mariadb-connector-c
+		mariadbconnector-c>=2.3.0:databases/mariadb-connector-c
 LIB_DEPENDS=    libodbc.so:databases/unixODBC
-RUN_DEPENDS=	mariadb-connector-c>=2.3.0:databases/mariadb-connector-c
+RUN_DEPENDS=	mariadbconnector-c>=2.3.0:databases/mariadb-connector-c
 
 CMAKE_ARGS+=	-DCOMPILATION_COMMENT="FreeBSD Ports"
 

--- a/databases/mariadb-connector-odbc/distinfo
+++ b/databases/mariadb-connector-odbc/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1501687550
-SHA256 (mariadb-connector-odbc-3.0.1-beta-src.tar.gz) = 03e3fbf5f3957c88bc89c45a8396c1aabf88ec86f21e5e6dd0c6ad09e30389aa
-SIZE (mariadb-connector-odbc-3.0.1-beta-src.tar.gz) = 192530
+TIMESTAMP = 1516788517
+SHA256 (mariadb-connector-odbc-3.0.2-ga-src.tar.gz) = eba4fbda21ae9d50c94d2cd152f0ec14dde3989522f41ef7d22aa0948882ff93
+SIZE (mariadb-connector-odbc-3.0.2-ga-src.tar.gz) = 193182

--- a/databases/mariadb-connector-odbc/distinfo
+++ b/databases/mariadb-connector-odbc/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1492185879
-SHA256 (mariadb-connector-odbc-2.0.14-ga-src.tar.gz) = 68ca3ecc9aadc5d6f748fbae239e8fce169d5d2470ee38ea8006dd497d38c3b0
-SIZE (mariadb-connector-odbc-2.0.14-ga-src.tar.gz) = 180385
+TIMESTAMP = 1501265815
+SHA256 (mariadb-connector-odbc-3.0.0-alpha-src.tar.gz) = 61a5b450fee5787f12f5cbfd903c9886ef1f7176ba518de27316a81549d8bad3
+SIZE (mariadb-connector-odbc-3.0.0-alpha-src.tar.gz) = 182088

--- a/databases/mariadb-connector-odbc/distinfo
+++ b/databases/mariadb-connector-odbc/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1501265815
-SHA256 (mariadb-connector-odbc-3.0.0-alpha-src.tar.gz) = 61a5b450fee5787f12f5cbfd903c9886ef1f7176ba518de27316a81549d8bad3
-SIZE (mariadb-connector-odbc-3.0.0-alpha-src.tar.gz) = 182088
+TIMESTAMP = 1501687550
+SHA256 (mariadb-connector-odbc-3.0.1-beta-src.tar.gz) = 03e3fbf5f3957c88bc89c45a8396c1aabf88ec86f21e5e6dd0c6ad09e30389aa
+SIZE (mariadb-connector-odbc-3.0.1-beta-src.tar.gz) = 192530

--- a/databases/mariadb-connector-odbc/pkg-descr
+++ b/databases/mariadb-connector-odbc/pkg-descr
@@ -4,4 +4,3 @@ used as a drop-in replacement for MySQL Connector/ODBC, and it supports
 both Unicode and ANSI modes.
 
 WWW: https://mariadb.com/kb/en/mariadb/mariadb-connector-odbc/
-


### PR DESCRIPTION
First: it was trying to download from "http://[url]/mariadb/-connector-odbc-2.0.14/source/mariadb-connector-odbc-2.0.14-ga-src.tar.gz" instead of "http://[url]/mariadb/connector-odbc-2.0.14/source/mariadb-connector-odbc-2.0.14-ga-src.tar.gz" (dash before "connector…")

Second: I don't know where the error comes from, but it needed "mariadbconnector-c" instead of "mariadb-connector-c" for its dependencies. In logs:
"===> mariadb-connector-odbc-2.0.14 depends on package: mariadb-connector-c>=2.3.0 - not found
===> Installing existing package /packages/All/mariadbconnector-c-2.3.1_1.txz"